### PR TITLE
Using Split.io sdk with Sidekiq.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "splitclient-rb", "~> 7.3.4"
+gem "sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-darwin)
+      racc (~> 1.4)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -140,6 +142,10 @@ GEM
     redis (4.6.0)
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
+    sidekiq (6.4.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     socketry (0.5.1)
       hitimes (~> 1.2)
     splitclient-rb (7.3.4)
@@ -174,6 +180,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-19
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -181,6 +188,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (>= 5.6.4)
   rails (~> 5.2.6, >= 5.2.6.3)
+  sidekiq
   splitclient-rb (~> 7.3.4)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,10 @@ class HomeController < ApplicationController
   end
 
   def show_test_global_feature_flag
-    status = SPLIT_CLIENT.get_treatment('global', 'test_global_feature_flag')
-    render json: { ok: true, status: status }
+    key_param = params[:key]
+    split_name_param = params[:split_name]
+    SplitEvaluationWorker.perform_async(key_param, split_name_param)
+
+    render json: { ok: true }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require "action_cable/engine"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+require "./sidekiq/app/workers/split_evaluation_worker"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/split_client.rb
+++ b/config/initializers/split_client.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 # NOTE: bad practice, just for a quick POC. Credentials should not exist in code!
-split_factory =
-  SplitIoClient::SplitFactory.new(ENV['SPLIT_IO_API_KEY'])
-SPLIT_CLIENT = split_factory.client
-Rails.configuration.split_factory = split_factory
+# split_factory =
+#   SplitIoClient::SplitFactory.new(ENV['SPLIT_IO_API_KEY'])
+# SPLIT_CLIENT = split_factory.client
+# Rails.configuration.split_factory = split_factory
 
-begin
-  SPLIT_CLIENT.block_until_ready
-rescue SplitIoClient::SDKBlockerTimeoutExpiredException => error 
-  Rails.logger.error '=> Split.io SDK is not ready'
-  raise error
-end
+# begin
+#   SPLIT_CLIENT.block_until_ready
+# rescue SplitIoClient::SDKBlockerTimeoutExpiredException => error 
+#   Rails.logger.error '=> Split.io SDK is not ready'
+#   raise error
+# end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -51,9 +51,9 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-before_fork { Rails.configuration.split_factory.stop! }
+# before_fork { Rails.configuration.split_factory.stop! }
 
-on_worker_boot { Rails.configuration.split_factory.resume! }
+# on_worker_boot { Rails.configuration.split_factory.resume! }
 
 # experimental puma cluster mode flags
 # https://github.com/puma/puma/blob/1840014e77c9c0b2e9e094135396c25dd3c1df52/5.0-Upgrade.md

--- a/sidekiq/app/workers/split_evaluation_worker.rb
+++ b/sidekiq/app/workers/split_evaluation_worker.rb
@@ -1,0 +1,11 @@
+require 'sidekiq'
+
+class SplitEvaluationWorker
+  include Sidekiq::Worker
+
+  def perform(key, split_name)
+    result = SPLIT_CLIENT.get_treatment(key, split_name)
+
+    puts "### Evaluation result: #{result}. key = #{key} || split = #{split_name}"
+  end
+end

--- a/sidekiq/config/application.rb
+++ b/sidekiq/config/application.rb
@@ -1,0 +1,26 @@
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+Bundler.require
+
+ENV["RACK_ENV"] ||= "development"
+
+module Example
+ class Application
+   def self.root
+     @root ||= File.dirname(File.expand_path('..', __FILE__))
+   end
+
+   def self.env
+     @env ||= ENV["RAILS_ENV"] || ENV["RACK_ENV"] || ENV["ENV"] || "development"
+   end
+
+   def self.logger
+     @logger ||= Logger.new(STDOUT)
+   end
+ end
+end
+
+require_relative "initializers/sidekiq"
+require_relative "initializers/split_client"
+require_relative "../app/workers/split_evaluation_worker"

--- a/sidekiq/config/initializers/sidekiq.rb
+++ b/sidekiq/config/initializers/sidekiq.rb
@@ -1,0 +1,3 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end

--- a/sidekiq/config/initializers/split_client.rb
+++ b/sidekiq/config/initializers/split_client.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# NOTE: bad practice, just for a quick POC. Credentials should not exist in code!\
+split_factory = SplitIoClient::SplitFactory.new(ENV['SPLIT_IO_API_KEY'])
+SPLIT_CLIENT = split_factory.client
+
+begin
+  SPLIT_CLIENT.block_until_ready
+rescue SplitIoClient::SDKBlockerTimeoutExpiredException => e
+  puts '=> Split.io SDK is not ready'
+  raise e
+end

--- a/sidekiq/config/sidekiq.yml
+++ b/sidekiq/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency: <%= ENV["CONCURRENCY"] || 25 %>
+:queues:
+ - default


### PR DESCRIPTION
Hi Team,

Using your poc, I just made some tests to configure Split.io with sidekiq. 
The idea of these changes is to initialize the Split.io SDK inside sidekiq's context and be able to use it in the workers (as you can see, I've commented on all the Split.io references in puma and rails configurations.)

1 - run Sidekiq `bundle exec sidekiq -e ${RACK_ENV:-development} -r ./sidekiq/config/application.rb -C ./sidekiq/config/sidekiq.yml`

2- run `rails s` and request: `http://localhost:3030/test_global_feature_flag?key=<<SOME-VALUE>>&split_name=<<YOUR-SPLIT-NAME>>`

3- You will see in the logs the result of the evaluations.